### PR TITLE
Statscache packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.rst
-graft fedmsg.d/
+include fedmsg.d/statscache.py
+recursive-include apache *
 include CHANGELOG.rst
 include COPYING
 include COPYING.LESSER

--- a/apache/statscache.cfg
+++ b/apache/statscache.cfg
@@ -1,0 +1,7 @@
+# Beware that the quotes around the values are mandatory
+# This is read as a Python source code file
+
+### Secret key for the Flask application
+SECRET_KEY='secret key goes here'
+
+# vim: set ft=python:

--- a/apache/statscache.conf
+++ b/apache/statscache.conf
@@ -1,0 +1,15 @@
+LoadModule wsgi_module modules/mod_wsgi.so
+
+WSGIPythonEggs /var/cache/statscache/.python-eggs
+WSGIDaemonProcess statscache user=apache group=statscache maximum-requests=50000 display-name=statscache processes=8 threads=4 inactivity-timeout=300
+WSGISocketPrefix run/wsgi
+WSGIRestrictStdout Off
+WSGIRestrictSignal Off
+WSGIPythonOptimize 1
+
+WSGIScriptAlias / /usr/share/statscache/statscache.wsgi
+
+<Directory /usr/share/statscache/>
+   Order deny,allow
+   Allow from all
+</Directory>

--- a/apache/statscache.wsgi
+++ b/apache/statscache.wsgi
@@ -1,0 +1,14 @@
+import __main__
+__main__.__requires__ = ['SQLAlchemy >= 0.7', 'jinja2 >= 2.4']
+import pkg_resources
+
+# http://stackoverflow.com/questions/8007176/500-error-without-anything-in-the-apache-logs
+import logging
+import sys
+logging.basicConfig(stream=sys.stderr)
+
+import statscache.app
+application = statscache.app.app
+#application.debug = True  # Nope.  Be careful!
+
+# vim: set ft=python:


### PR DESCRIPTION
@ralphbean 

This branch contains changes required to be made to the repo for the purpose of packaging it.

Here's an initial SPEC file written: https://gist.github.com/rtnpro/20075dd4df631729d898
I am a bit confused about the files under `fedmsg.d/` dir? Is it only for development. As I see, the files in the `fedmsg` dir conflicts with the ones installed by `fedmsg` RPM package. Am I supposed to include only `fedmsg.d/statscache.py` in the package? What about logging conf? 
Or, shall I exclude them from the package totally and `ansible` scripts take care of them, as done in, https://infrastructure.fedoraproject.org/cgit/ansible.git/tree/roles/datagrepper/tasks/main.yml.
Please have a look and comment.
