### PR TITLE
Plugin initialization bugfix

### DIFF
--- a/statscache/app.py
+++ b/statscache/app.py
@@ -2,11 +2,13 @@ import flask
 import fedmsg.config
 import statscache.plugins
 import statscache.utils
+import statscache.frequency
 import json
 
 app = flask.Flask(__name__)
 
 config = fedmsg.config.load_config()
+plugins = {} # mapping of identifiers to plugin instances
 
 uri = config['statscache.sqlalchemy.uri']
 session = statscache.plugins.init_model(uri)
@@ -16,7 +18,11 @@ session = statscache.plugins.init_model(uri)
 def main(name):
     """ Generate a JSON-P response with the content of the plugin's model """
     callback = flask.request.args.get('callback')
-    model = statscache.utils.get_model(name, config)
+    model = None
+    try:
+        model = plugins.get(name).model
+    except AttributeError:
+        raise KeyError("No such model for %r" % name)
     results = session.query(model).all()
     body = model.to_json(results)
     if callback:
@@ -33,7 +39,7 @@ def main(name):
 @app.route('/<name>/layout')
 def plugin_layout(name):
     """ Generate a JSON-P response with the content of the plugin's layout """
-    plugin = statscache.utils.get_plugin(name, config)
+    plugin = plugins.get(name)
     body = ''
     status = 404
     callback = flask.request.args.get('callback')
@@ -51,6 +57,15 @@ def plugin_layout(name):
 
 
 if __name__ == '__main__':
+    # initialize plugins
+    frequencies = { None: None } # mapping of intervals to reusable Frequency instances
+    for plugin_class in statscache.utils.plugin_classes:
+        if plugin_class.interval not in frequencies:
+            frequencies[plugin_class.interval] = \
+                statscache.frequency.Frequency(plugin_class.interval)
+        plugin = plugin_class(frequencies[plugin_class.interval], config)
+        plugins[plugin.ident] = plugin
+    # ...and fire up the web app
     app.run(
         debug=True,
     )

--- a/statscache/frequency.py
+++ b/statscache/frequency.py
@@ -2,15 +2,25 @@ import datetime
 
 
 class Frequency(object):
-    """ A repeating interval synchronized on an epoch """
-    def __init__(self, interval, epoch):
+    """
+    A repeating interval synchronized on an epoch, which defaults to UTC
+    midnight of the current day (when this class definiton was loaded).
+    """
+
+    # synchronize all frequencies on UTC midnight of current day
+    epoch = datetime.datetime.utcnow().replace(hour=0,
+                                               minute=0,
+                                               second=0,
+                                               microsecond=0)
+
+    def __init__(self, interval, epoch=None):
         # synchronize on UTC midnight of the day of creation
-        if not isinstance(interval, datetime.timedelta):
-            raise TypeError("'interval' must be an instance of 'timedelta'")
         self.interval = interval
-        if not isinstance(epoch, datetime.datetime):
+        if not isinstance(self.interval, datetime.timedelta):
+            raise TypeError("'interval' must be an instance of 'timedelta'")
+        self.epoch = epoch or Frequency.epoch
+        if not isinstance(self.epoch, datetime.datetime):
             raise TypeError("'epoch' must be an instance of 'datetime'")
-        self.epoch = epoch
 
     @property
     def days(self):

--- a/statscache/producer.py
+++ b/statscache/producer.py
@@ -43,8 +43,7 @@ class StatsProducerBase(moksha.hub.api.PollingProducer):
                 initialize = getattr(plugin, 'initialize', None)
                 if initialize is not None:
                     plugin.initialize(session)
-                statscache.utils.register_plugin(plugin, self.hub.config)
-                session.commit()
+                    session.commit()
                 self.plugins.append(plugin)
                 log.info("Initialized plugin %r" % plugin.ident)
             except Exception:

--- a/statscache/producer.py
+++ b/statscache/producer.py
@@ -94,16 +94,11 @@ def factory():
         if isinstance(interval, datetime.timedelta):
             plugins_by_interval[interval].append(plugin_class)
 
-    # synchronize all frequencies on UTC midnight of current day
-    epoch = datetime.datetime.utcnow().replace(hour=0,
-                                               minute=0,
-                                               second=0,
-                                               microsecond=0)
     for interval, plugin_classes in plugins_by_interval.items():
         class StatsProducerAnon(StatsProducerBase):
             """ Dynamically generated class for a specific frequency """
             pass # we need to programmatically set class attributes
-        frequency = statscache.frequency.Frequency(interval, epoch)
+        frequency = statscache.frequency.Frequency(interval)
         StatsProducerAnon.frequency = frequency
         StatsProducerAnon.plugin_classes = plugin_classes
         StatsProducerAnon.__name__ = 'StatsProducer' + str(frequency)

--- a/statscache/utils.py
+++ b/statscache/utils.py
@@ -1,6 +1,5 @@
 import inspect
 import pkg_resources
-from collections import defaultdict
 
 import statscache.plugins
 
@@ -46,21 +45,3 @@ def load_plugins():
 
 # load the available plugin classes once and save them
 plugin_classes = load_plugins()
-
-
-plugin_table = defaultdict(dict)
-
-
-def register_plugin(plugin, config):
-    plugin_table[hash(str(config))][plugin.ident] = plugin
-
-
-def get_plugin(ident, config):
-    return plugin_table[hash(str(config))].get(ident)
-
-
-def get_model(ident, config):
-    plugin = get_plugin(ident, config)
-    if plugin:
-        return plugin.model
-    raise KeyError("No such model for %r" % (ident))


### PR DESCRIPTION
With dynamic producer generation, plugin initialization is now tied to the that of the associated producers, but the statscache frontend needs the plugin instances without also starting up the backend in the same process. This is a detail that I had missed in the initial pull request. Because of it, the web interface will report no plugins loaded at all. Given how differently the frontend and backend access and initialize the plugins, I could see no real benefit in using a common table in `statscache.utils` as before, and I instead introduced a simple identifier-to-plugin dictionary in the web app (which is itself tied to a particular hub configuration). With this change, all models exposed by plugins are made available by the web interface, resolving the issue.

Apologies for not catching this sooner :p
