### PR TITLE
Serve a JSON-P list of plugins as root index

### DIFF
--- a/statscache/app.py
+++ b/statscache/app.py
@@ -38,13 +38,14 @@ def index():
 def main(name):
     """ Generate a JSON-P response with the content of the plugin's model """
     callback = flask.request.args.get('callback')
-    model = None
-    try:
-        model = plugins.get(name).model
-    except AttributeError:
-        raise KeyError("No such model for %r" % name)
-    results = session.query(model).all()
-    return jsonp(model.to_json(results), 200)
+    status = 404
+    body = '"No such model for \'{}\'"'.format(name)
+    plugin = plugins.get(name)
+    if hasattr(plugin, 'model'):
+        model = plugin.model
+        status = 200
+        body = model.to_json(session.query(model).all())
+    return jsonp(body, status)
 
 
 @app.route('/<name>/layout')

--- a/statscache/app.py
+++ b/statscache/app.py
@@ -54,7 +54,6 @@ def plugin_layout(name):
     plugin = plugins.get(name)
     body = '"No such layout for \'{}\'"'.format(name)
     status = 404
-    mimetype = 'application/javascript'
     if plugin and hasattr(plugin, 'layout'):
         body = json.dumps(plugin.layout)
         status = 200

--- a/statscache/app.py
+++ b/statscache/app.py
@@ -28,6 +28,12 @@ def jsonp(body, status):
     )
 
 
+@app.route('/')
+def index():
+    """ Generate a JSON-P response with an index of plugins (as an array) """
+    return jsonp(json.dumps(plugins.keys()), 200)
+
+
 @app.route('/<name>')
 def main(name):
     """ Generate a JSON-P response with the content of the plugin's model """

--- a/statscache/app.py
+++ b/statscache/app.py
@@ -52,7 +52,7 @@ def main(name):
 def plugin_layout(name):
     """ Generate a JSON-P response with the content of the plugin's layout """
     plugin = plugins.get(name)
-    body = ''
+    body = '"No such layout for \'{}\'"'.format(name)
     status = 404
     mimetype = 'application/javascript'
     if plugin and hasattr(plugin, 'layout'):


### PR DESCRIPTION
Generate a JSON-P response to requests at the root index (`/`) of the statscache web interface containing a simple list of the available plugins. Additionally separate out the common logic for preparing a JSON-P response into a small helper function. In the future, we may wish to also include whether each plugin has a layout attribute or what serialization formats are specifically supported.
