### PR TITLE
Add default JSON/CSV serialization methods

### DIFF
--- a/statscache/app.py
+++ b/statscache/app.py
@@ -41,7 +41,7 @@ def get_mimetype():
     ]) or ""
 
 
-@app.route('/')
+@app.route('/api/')
 def plugin_index():
     """ Generate a JSON-P response with an index of plugins (as an array) """
     mimetype = get_mimetype()
@@ -50,7 +50,7 @@ def plugin_index():
     return jsonp(json.dumps(plugins.keys()))
 
 
-@app.route('/<name>')
+@app.route('/api/<name>')
 def plugin_model(name):
     """ Generate a JSON-P response with the content of the plugin's model """
     plugin = plugins.get(name)
@@ -73,7 +73,7 @@ def plugin_model(name):
         flask.abort(406)
 
 
-@app.route('/<name>/layout')
+@app.route('/api/<name>/layout')
 def plugin_layout(name):
     """ Generate a JSON-P response with the content of the plugin's layout """
     plugin = plugins.get(name)

--- a/statscache/plugins.py
+++ b/statscache/plugins.py
@@ -45,7 +45,7 @@ class BaseModelClass(object):
         """ Default CSV serializer """
         def serialize(obj):
             if isinstance(obj, datetime.datetime):
-                return time.mktime(obj.timetuple())
+                return str(time.mktime(obj.timetuple()))
             else:
                 return str(obj)
         def concat(xs, ys):
@@ -56,7 +56,7 @@ class BaseModelClass(object):
         columns.sort()
         columns.insert(0, 'timestamp')
         return '\n'.join(concat(
-            ','.join(columns),
+            [','.join(columns)],
             [
                 ','.join([
                     serialize(getattr(ins, col))


### PR DESCRIPTION
Include default JSON and CSV serialization methods in the base SQLAlchemy model class `statscache.plugins.BaseModelClass`. Additionally, select the proper serialization method based on the HTTP Accept header in requests and relocate stats model endpoints under `/api/` to reserve the top-level for an HTML site.

Note that I did not implement `/api/<plugin>/<format>` to select the mime-type, since that would be inconsistent with `/api/<plugin>/layout`. More generally, I do not really see a need to allow arbitrary serialization content-types, after giving it some thought. For one, JSON will cover the majority of uses. Second, the plugins ought to be somewhat consistent in content-type support; support for a specific content-type won't be too useful if it only works with one particular plugin. If I'm missing something in my logic, please do feel free to say so. :) That being said, we could still expose content-type preference through the URL as a query string argument, if there is a use-case where an HTTP Accept header cannot be produced.
