### PR TITLE
Refactor model class creation out of plugin initialization

### DIFF
--- a/statscache/plugins.py
+++ b/statscache/plugins.py
@@ -138,13 +138,15 @@ class BasePlugin(object):
     summary = None
     description = None
     interval = None # this must be either None or a datetime.timedelta instance
+    model = None
 
     datagrepper_endpoint = 'https://apps.fedoraproject.org/datagrepper/raw/'
 
     def __init__(self, frequency, config, model=None):
         self.frequency = frequency
         self.config = config
-        self.model = model or self.make_model()
+        if model:
+            self.model = model
 
         required = ['name', 'summary', 'description']
         for attr in required:

--- a/statscache/producer.py
+++ b/statscache/producer.py
@@ -40,16 +40,15 @@ class StatsProducerBase(moksha.hub.api.PollingProducer):
         self.plugins = []
         for plugin_class in self.plugin_classes:
             plugin = plugin_class(self.frequency, self.hub.config)
-            self.plugins.append(plugin)
             try:
                 initialize = getattr(plugin, 'initialize', None)
                 if initialize is not None:
                     plugin.initialize(session)
                     session.commit()
                 log.info("Initialized plugin %r" % plugin.ident)
+                self.plugins.append(plugin)
             except Exception:
                 log.exception("Failed to initialize plugin %r" % plugin)
-                del self.plugins[-1] # remove the dud plugin instance
                 session.rollback()
 
     def make_session(self):

--- a/statscache/producer.py
+++ b/statscache/producer.py
@@ -31,23 +31,16 @@ class StatsProducerBase(moksha.hub.api.PollingProducer):
         log.debug("%s initialized with %r plugins" % (
             type(self).__name__, len(self.plugin_classes)))
 
-        # Loop over all our plugins twice, pausing in the middle to create
-        # their db tables if necessary.
-        self.plugins = []
-        for plugin_class in self.plugin_classes:
-            plugin = plugin_class(self.frequency, self.hub.config)
-            self.plugins.append(plugin)
-            log.info("Instantiated plugin %r" % plugin.ident)
-
         # Create any absent db tables (were new plugins installed?)
         uri = self.hub.config['statscache.sqlalchemy.uri']
         statscache.plugins.create_tables(uri)
 
-        # Finally, call the initialize method of any plugins that have one.
-        # This typically makes long queries to datagrepper for historical
-        # information.
+        # Loop over our plugin classes to instantiate and initialize them
         session = self.make_session()
-        for plugin in self.plugins:
+        self.plugins = []
+        for plugin_class in self.plugin_classes:
+            plugin = plugin_class(self.frequency, self.hub.config)
+            self.plugins.append(plugin)
             try:
                 initialize = getattr(plugin, 'initialize', None)
                 if initialize is not None:
@@ -56,8 +49,7 @@ class StatsProducerBase(moksha.hub.api.PollingProducer):
                 log.info("Initialized plugin %r" % plugin.ident)
             except Exception:
                 log.exception("Failed to initialize plugin %r" % plugin)
-                # TODO -- if the plugin fails to initialize we should remove it
-                # from `self.plugins`.
+                del self.plugins[-1] # remove the dud plugin instance
                 session.rollback()
 
     def make_session(self):


### PR DESCRIPTION
Instead of a `make_model()` method, require each plugin class to define its model class as a `model` attribute, created prior to plugin initialization or set to `None` if the plugin expects to receive its model class an initialization parameter. This allows for simplification in the stats producer initialization and also in the plugins themselves.

Although this disallows "dynamic" generation of model classes, we aren't sacrificing any usable functionality, since model classes should not have any dependence on the initialization conditions of the plugin. The only use of `make_model()` in a capacity greater than simply returning a predefined class is by the volume plugins, which are parametrized by the frequency at which they calculate their statistics. This can be accomplished just as well by implementing a plugin/model class factory, which is what is done in the [accompanying pull request](https://github.com/fedora-infra/statscache_plugins/pull/8) to `statscache_plugins`.
