### PR TITLE
Real-time message processing and synchronized database updates

### DIFF
--- a/fedmsg.d/statscache.py
+++ b/fedmsg.d/statscache.py
@@ -8,7 +8,7 @@ config = {
     "statscache.consumer.enabled": True,
     "statscache.sqlalchemy.uri": "sqlite:////var/tmp/statscache-dev-db.sqlite",
     # stats models will go back at least this far (current value arbitrary)
-    "statscache.consumer.epoch": datetime.datetime(year=2015, month=6, day=1),
+    "statscache.consumer.epoch": datetime.datetime(year=2015, month=8, day=8),
     # stats models are updated at this frequency
     "statscache.producer.frequency": datetime.timedelta(seconds=1),
     # Turn on logging for statscache

--- a/fedmsg.d/statscache.py
+++ b/fedmsg.d/statscache.py
@@ -1,4 +1,5 @@
 import socket
+import datetime
 hostname = socket.gethostname().split('.')[0]
 
 
@@ -6,7 +7,10 @@ config = {
     # Consumer stuff
     "statscache.consumer.enabled": True,
     "statscache.sqlalchemy.uri": "sqlite:////var/tmp/statscache-dev-db.sqlite",
-
+    # stats models will go back at least this far (current value arbitrary)
+    "statscache.consumer.epoch": datetime.datetime(year=2015, month=6, day=1),
+    # stats models are updated at this frequency
+    "statscache.producer.frequency": datetime.timedelta(seconds=1),
     # Turn on logging for statscache
     "logging": dict(
         loggers=dict(

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
             "statscache_consumer = statscache.consumer:StatsConsumer",
         ],
         'moksha.producer': [
-            "statscache_producers = statscache.producer:producers",
+            "statscache_producer = statscache.producer:StatsProducer",
         ],
     },
 )

--- a/statscache/app.py
+++ b/statscache/app.py
@@ -15,7 +15,9 @@ MAXIMUM_ROWS_PER_PAGE = 100
 app = flask.Flask(__name__)
 
 config = fedmsg.config.load_config()
-plugins = {} # mapping of identifiers to plugin instances
+plugins = {
+    plugin.ident: plugin for plugin in statscache.utils.init_plugins(config)
+} # mapping of identifiers to plugin instances
 
 uri = config['statscache.sqlalchemy.uri']
 session = statscache.plugins.init_model(uri)
@@ -209,15 +211,6 @@ def unacceptable_content(error):
 
 
 if __name__ == '__main__':
-    # initialize plugins
-    frequencies = { None: None } # mapping of intervals to Frequency instances
-    for plugin_class in statscache.utils.plugin_classes:
-        if plugin_class.interval not in frequencies:
-            frequencies[plugin_class.interval] = \
-                statscache.frequency.Frequency(plugin_class.interval)
-        plugin = plugin_class(frequencies[plugin_class.interval], config)
-        plugins[plugin.ident] = plugin
-    # ...and fire up the web app
     app.run(
         debug=True,
     )

--- a/statscache/consumer.py
+++ b/statscache/consumer.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 
+import fedmsg.meta
 import fedmsg.consumers
 import statscache.utils
 
@@ -23,6 +24,8 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
         # fedmsg traffic that was missed while offline therefore extends
         # from some unkown point(s) in the past until now.
         end_backlog = datetime.datetime.now()
+
+        fedmsg.meta.make_processors(**self.hub.config)
 
         # Instantiate plugins
         self.plugins = statscache.utils.init_plugins(self.hub.config)

--- a/statscache/consumer.py
+++ b/statscache/consumer.py
@@ -41,10 +41,13 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
         session = statscache.plugins.init_model(uri)
 
         # Compute pairs of plugins and the point up to which they are accurate
-        fst = lambda (x, _): x
         plugins_by_age = []
-        for (age, plugin) in sorted([(plugin.latest(session) or epoch, plugin)
-                                     for plugin in self.plugins], key=fst):
+        for (age, plugin) in sorted([
+                                        (plugin.latest(session) or epoch,
+                                         plugin)
+                                        for plugin in self.plugins
+                                    ],
+                                    key=lambda (age, _): age):
             if len(plugins_by_age) > 0 and plugins_by_age[-1][0] == age:
                 plugins_by_age[-1][1].append(plugin)
             else:

--- a/statscache/consumer.py
+++ b/statscache/consumer.py
@@ -70,7 +70,8 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
                 for plugin in self.plugins:
                     # Delete any partially completed rows, timestamped at start
                     plugin.revert(start, session)
-                    map(plugin.process, copy.deepcopy(messages))
+                    for message in messages:
+                        plugin.process(copy.deepcopy(message))
                     plugin.update(session)
         log.debug("statscache consumer initialized")
 

--- a/statscache/consumer.py
+++ b/statscache/consumer.py
@@ -22,7 +22,7 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
         super(StatsConsumer, self).__init__(*args, **kwargs)
         # From now on, incoming messages will be queued. The backlog of
         # fedmsg traffic that was missed while offline therefore extends
-        # from some unkown point(s) in the past until now.
+        # from some unknown point(s) in the past until now.
         end_backlog = datetime.datetime.now()
 
         fedmsg.meta.make_processors(**self.hub.config)

--- a/statscache/consumer.py
+++ b/statscache/consumer.py
@@ -1,6 +1,7 @@
 import copy
 
 import fedmsg.consumers
+import statscache.utils
 
 import logging
 log = logging.getLogger("fedmsg")
@@ -17,19 +18,39 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
         """ Instantiate the consumer and a default list of buckets """
         log.debug("statscache consumer initializing")
         super(StatsConsumer, self).__init__(*args, **kwargs)
-        log.debug("statscache consumer initialized")
-        self.producers = []
 
-    def register(self, producer):
-        """ Method to register a producer """
-        self.producers.append(producer)
+        # Instantiate plugins
+        self.plugins = statscache.utils.init_plugins(self.hub.config)
+        log.info("instantiated plugins: " +
+            ', '.join([plugin.ident for plugin in self.plugins])
+        )
+
+        # Create any absent db tables (were new plugins installed?)
+        uri = self.hub.config['statscache.sqlalchemy.uri']
+        statscache.plugins.create_tables(uri)
+
+        # Prepare to process backlogged fedmsg traffic
+        session = statscache.plugins.init_model(uri)
+
+        for plugin in self.plugins:
+            try:
+                if hasattr(plugin, 'initialize'):
+                    plugin.initialize(session)
+                log.info("Initialized plugin %r" % plugin.ident)
+            except Exception as e:
+                log.exception(
+                    "Failed to initialize plugin %r: %s" % (plugin.ident, e)
+                )
+                session.rollback()
+
+        log.debug("statscache consumer initialized")
 
     def consume(self, raw_msg):
         """ Receive a message and enqueue it onto each bucket """
         topic, msg = raw_msg['topic'], raw_msg['body']
         log.info("Got message %r", topic)
-        for producer in self.producers:
-            producer.buffer(copy.deepcopy(msg))
+        for plugin in self.plugins:
+            plugin.process(copy.deepcopy(msg))
 
     def stop(self):
         log.info("Cleaning up StatsConsumer.")

--- a/statscache/consumer.py
+++ b/statscache/consumer.py
@@ -69,10 +69,11 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
             (stop, _) = next(plugins_by_age_iter, (end_backlog, None))
             log.info("consuming historical fedmsg traffic from %s up to %s"
                 % (start, stop))
+            # Delete any partially completed rows, timestamped at start
+            for plugin in self.plugins:
+                plugin.revert(start, session)
             for messages in statscache.utils.datagrep(start, stop):
                 for plugin in self.plugins:
-                    # Delete any partially completed rows, timestamped at start
-                    plugin.revert(start, session)
                     for message in messages:
                         plugin.process(copy.deepcopy(message))
                     plugin.update(session)

--- a/statscache/frequency.py
+++ b/statscache/frequency.py
@@ -2,23 +2,13 @@ import datetime
 
 
 class Frequency(object):
-    """
-    A repeating interval synchronized on an epoch, which defaults to UTC
-    midnight of the current day (when this class definiton was loaded).
-    """
+    """ A repeating interval synchronized at a point in time (the "epoch") """
 
-    # synchronize all frequencies on UTC midnight of current day
-    epoch = datetime.datetime.utcnow().replace(hour=0,
-                                               minute=0,
-                                               second=0,
-                                               microsecond=0)
-
-    def __init__(self, interval, epoch=None):
-        # synchronize on UTC midnight of the day of creation
+    def __init__(self, interval, epoch):
         self.interval = interval
         if not isinstance(self.interval, datetime.timedelta):
             raise TypeError("'interval' must be an instance of 'timedelta'")
-        self.epoch = epoch or Frequency.epoch
+        self.epoch = epoch
         if not isinstance(self.epoch, datetime.datetime):
             raise TypeError("'epoch' must be an instance of 'datetime'")
 

--- a/statscache/plugins.py
+++ b/statscache/plugins.py
@@ -144,8 +144,8 @@ class BasePlugin(object):
 
     datagrepper_endpoint = 'https://apps.fedoraproject.org/datagrepper/raw/'
 
-    def __init__(self, frequency, config, model=None):
-        self.frequency = frequency
+    def __init__(self, schedule, config, model=None):
+        self.schedule = schedule
         self.config = config
         if model:
             self.model = model
@@ -166,9 +166,9 @@ class BasePlugin(object):
         replacements = dict(zip(bad, [''] * len(bad)))
         for a, b in replacements.items():
             ident = ident.replace(a, b)
-        frequency = getattr(self, 'frequency', None)
-        if frequency:
-            ident += '-{}'.format(frequency)
+        schedule = getattr(self, 'schedule', None)
+        if schedule:
+            ident += '-{}'.format(schedule)
         return ident
 
     @abc.abstractmethod

--- a/statscache/plugins.py
+++ b/statscache/plugins.py
@@ -137,6 +137,7 @@ class BasePlugin(object):
     name = None
     summary = None
     description = None
+
     interval = None # this must be either None or a datetime.timedelta instance
     model = None
 
@@ -170,6 +171,11 @@ class BasePlugin(object):
         return ident
 
     @abc.abstractmethod
-    def handle(self, session, messages):
-        """ Process a list of messages using the given database session """
+    def process(self, message):
+        """ Process a message """
+        pass
+
+    @abc.abstractmethod
+    def update(self, session):
+        """ Update the model using the database session """
         pass

--- a/statscache/plugins.py
+++ b/statscache/plugins.py
@@ -186,9 +186,10 @@ class BasePlugin(object):
         times = [
             # This is the _actual_ latest datetime
             getattr(session.query(self.model)\
-                    .order_by( self.model.timestamp.desc())\
+                    .order_by(self.model.timestamp.desc())\
                     .first(), 
-                    'timestamp')
+                    'timestamp',
+                    None)
         ]
         if self.backlog_delta is not None:
             # This will limit how far back to process data, if statscache has

--- a/statscache/producer.py
+++ b/statscache/producer.py
@@ -1,7 +1,6 @@
 import datetime
 from collections import defaultdict
 
-import fedmsg.meta
 import moksha.hub.api
 
 import statscache.plugins
@@ -23,8 +22,6 @@ class StatsProducer(moksha.hub.api.PollingProducer):
         log.debug("statscache producer initializing")
         self.frequency = hub.config['statscache.producer.frequency']
         super(StatsProducer, self).__init__(hub)
-
-        fedmsg.meta.make_processors(**self.hub.config)
 
         # grab the list of plugins from the consumer
         self.plugins = statscache.utils.find_stats_consumer(self.hub).plugins

--- a/statscache/producer.py
+++ b/statscache/producer.py
@@ -13,9 +13,8 @@ log = logging.getLogger("fedmsg")
 
 class StatsProducer(moksha.hub.api.PollingProducer):
     """
-    An abstract base class for dynamically generated producers. Subclasses need
-    only define 'frequency' and 'plugin_classes' attributes as well as define a
-    unique class name for themselves.
+    This class periodically visits all the plugins to request that they update
+    their database models.
     """
 
     def __init__(self, hub):

--- a/statscache/schedule.py
+++ b/statscache/schedule.py
@@ -1,14 +1,24 @@
 import datetime
 
 
-class Frequency(object):
-    """ A repeating interval synchronized at a point in time (the "epoch") """
+class Schedule(object):
+    """
+    A repeating interval synchronized on an epoch, which defaults to UTC
+    midnight of the current day (when this class definiton was loaded).
+    """
 
-    def __init__(self, interval, epoch):
+    # synchronize all frequencies on UTC midnight of current day
+    epoch = datetime.datetime.utcnow().replace(hour=0,
+                                               minute=0,
+                                               second=0,
+                                               microsecond=0)
+
+    def __init__(self, interval, epoch=None):
+        # synchronize on UTC midnight of the day of creation
         self.interval = interval
         if not isinstance(self.interval, datetime.timedelta):
             raise TypeError("'interval' must be an instance of 'timedelta'")
-        self.epoch = epoch
+        self.epoch = epoch or Frequency.epoch
         if not isinstance(self.epoch, datetime.datetime):
             raise TypeError("'epoch' must be an instance of 'datetime'")
 

--- a/statscache/utils.py
+++ b/statscache/utils.py
@@ -60,7 +60,7 @@ def init_plugins(config):
         if issubclass(plugin_class, statscache.plugins.BasePlugin):
             interval = plugin_class.interval
             if interval not in frequencies:
-                frequencies[interval] = Frequency(interval, epoch=epoch)
+                frequencies[interval] = Frequency(interval, epoch)
             plugins.append(plugin_class(frequencies[interval], config))
 
     epoch = config['statscache.consumer.epoch']

--- a/statscache/utils.py
+++ b/statscache/utils.py
@@ -70,7 +70,8 @@ def init_plugins(config):
             entry_object = entry_point.load()
             # the entry-point object is either a plugin or a collection of them
             try:
-                map(init_plugin, entry_object)
+                for entry_element in entry_object:
+                    init_plugin(entry_element)
             except TypeError:
                 init_plugin(entry_object)
         except Exception:

--- a/statscache/utils.py
+++ b/statscache/utils.py
@@ -3,9 +3,8 @@ import pkg_resources
 import requests
 import time
 
-from statscache.frequency import Frequency
+from statscache.schedule import Schedule
 import statscache.plugins
-from statscache.frequency import Frequency
 
 import logging
 log = logging.getLogger("fedmsg")
@@ -59,12 +58,12 @@ def init_plugins(config):
     def init_plugin(plugin_class):
         if issubclass(plugin_class, statscache.plugins.BasePlugin):
             interval = plugin_class.interval
-            if interval not in frequencies:
-                frequencies[interval] = Frequency(interval, epoch)
-            plugins.append(plugin_class(frequencies[interval], config))
+            if interval not in schedules:
+                schedules[interval] = Schedule(interval, epoch)
+            plugins.append(plugin_class(schedules[interval], config))
 
     epoch = config['statscache.consumer.epoch']
-    frequencies = { None: None }  # reusable Frequency instances
+    schedules = { None: None }  # reusable Schedule instances
     plugins = []
     for entry_point in pkg_resources.iter_entry_points('statscache.plugin'):
         try:

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -6,41 +6,41 @@ import nose.tools
 
 
 from datetime import datetime, timedelta
-from statscache.frequency import Frequency
+from statscache.schedule import Schedule
 
 def midnight_of(day):
     return day.replace(hour=0, minute=0, second=0, microsecond=0)
 
-class TestFrequency(unittest.TestCase):
+class TestSchedule(unittest.TestCase):
 
     @freezegun.freeze_time('2012-01-14 00:00:00')
     def test_basic(self):
         now = datetime.now()
-        f = Frequency(timedelta(minutes=15, hours=5), midnight_of(now))
+        f = Schedule(timedelta(minutes=15, hours=5), midnight_of(now))
         self.assertEquals(float(f), (5 * 60 + 15) * 60)
 
     @freezegun.freeze_time('2012-01-14 00:00:00')
     def test_one_second(self):
         now = datetime.now()
-        f = Frequency(timedelta(seconds=1), midnight_of(now))
+        f = Schedule(timedelta(seconds=1), midnight_of(now))
         self.assertEquals(float(f), 1)
 
     @freezegun.freeze_time('2012-01-14 00:00:01')
     def test_one_second_ahead(self):
         now = datetime.now()
-        f = Frequency(timedelta(seconds=1), midnight_of(now))
+        f = Schedule(timedelta(seconds=1), midnight_of(now))
         self.assertEquals(float(f), 1)
 
     @freezegun.freeze_time('2012-01-14 00:00:00')
     def test_two_seconds(self):
         now = datetime.now()
-        f = Frequency(timedelta(seconds=2), midnight_of(now))
+        f = Schedule(timedelta(seconds=2), midnight_of(now))
         self.assertEquals(float(f), 2)
 
     @freezegun.freeze_time('2012-01-14 00:00:00')
     def test_working_with_time_sleep(self):
         now = datetime.now()
-        f = Frequency(timedelta(seconds=1), midnight_of(now))
+        f = Schedule(timedelta(seconds=1), midnight_of(now))
 
         value = float(f)
         # Be careful not to sleep for 20 years if there's a bug
@@ -52,45 +52,45 @@ class TestFrequency(unittest.TestCase):
     @freezegun.freeze_time('2012-01-14 04:00:00')
     def test_last_before_epoch(self):
         now = datetime.now()
-        f = Frequency(timedelta(minutes=15, hours=5), now)
+        f = Schedule(timedelta(minutes=15, hours=5), now)
         self.assertEquals(f.last(now=(now - timedelta(seconds=1))),
             datetime(year=2012, month=1, day=13, hour=22, minute=45))
 
     @freezegun.freeze_time('2012-01-14 05:19:27')
     def test_last_on_epoch(self):
         now = datetime.now()
-        f = Frequency(timedelta(hours=5, minutes=20, seconds=30), midnight_of(now))
+        f = Schedule(timedelta(hours=5, minutes=20, seconds=30), midnight_of(now))
         self.assertEquals(f.last(), datetime(year=2012, month=1, day=14))
 
     @nose.tools.raises(TypeError)
     def test_invalid_interval(self):
-        Frequency('banana', datetime.utcnow())
+        Schedule('banana', datetime.utcnow())
 
     @nose.tools.raises(TypeError)
     def test_invalid_epoch(self):
-        Frequency(timedelta(seconds=15), 'squirrels')
+        Schedule(timedelta(seconds=15), 'squirrels')
 
 
 class TestFrequencyString(unittest.TestCase):
 
     def test_second(self):
-        f = Frequency(timedelta(seconds=10), datetime.utcnow())
+        f = Schedule(timedelta(seconds=10), datetime.utcnow())
         self.assertEqual(str(f), '10s')
 
     def test_minute(self):
-        f = Frequency(timedelta(minutes=10), datetime.utcnow())
+        f = Schedule(timedelta(minutes=10), datetime.utcnow())
         self.assertEqual(str(f), '10m')
 
     def test_hour(self):
-        f = Frequency(timedelta(hours=1), datetime.utcnow())
+        f = Schedule(timedelta(hours=1), datetime.utcnow())
         self.assertEqual(str(f), '1h')
 
     def test_hour(self):
-        f = Frequency(timedelta(days=1), datetime.utcnow())
+        f = Schedule(timedelta(days=1), datetime.utcnow())
         self.assertEqual(str(f), '1d')
 
     def test_all(self):
-        f = Frequency(timedelta(days=1, hours=1, minutes=1, seconds=1),
+        f = Schedule(timedelta(days=1, hours=1, minutes=1, seconds=1),
                       datetime.utcnow())
         self.assertEqual(str(f), '1d1h1m1s')
 


### PR DESCRIPTION
I've written a working implementation of my second proposed re-architecturing solution, described in my issue [here](https://github.com/fedora-infra/statscache/issues/23#issuecomment-126097527). During normal operation, this is not that big of a change. When a message is received, a deep copy is directly handed to each plugin by the fedmsg consumer for processing, and each plugin stores whatever the results are of this processing internally. For example, volume plugins do something along the lines of `self._volumes[(msg.timestamp, key(msg))]  += 1` where `self._volumes` is a `collections.defaultdict`. On a configurable frequency, a polling producer instructs each plugin to update its database model with its stored results.

At startup, things do change quite a bit. For one, there is no longer a need for such a complicated plugin/producer initialization relationship (where the polling producers needed to be generated after plugins were loaded but before they were instantiated). Additionally, the plugin `initialize()` method, used to process backlogged messages, is removed in favor of doing this centrally in the fedmsg consumer initialization. This is good for encapsulation, as all operations related to message retrieval, receipt, and distribution happen in the same class. Since patchy data can't give us all that much insight, I've also added a configuration value for the "epoch" of statistics. This is the date and time as of which statscache will have uninterruptedly processed all fedmsg traffic. However, some plugins (the releng one in particular comes to mind) really do only care about somewhat recent messages. To support this, plugins are able to modify this continuity, basically by lying about how up-to-date they are (_i.e._, reporting that they are up-to-date as of `max(datetime.now() - self.backlog_delta, latest_row.timestamp)`). Of course, it must then be noted that historical data in such models will be spotty or possibly even nonexistent.

Note: Due to the fact that consensus was never reached in the original issue, please feel free to consider this an RFC or WIP if there are objections.
