### PR TITLE
Concurrently query datagrepper during start-up

### DIFF
--- a/fedmsg.d/statscache.py
+++ b/fedmsg.d/statscache.py
@@ -4,6 +4,7 @@ hostname = socket.gethostname().split('.')[0]
 
 
 config = {
+    "statscache.datagrepper.workers": 8,
     # Consumer stuff
     "statscache.consumer.enabled": True,
     "statscache.sqlalchemy.uri": "sqlite:////var/tmp/statscache-dev-db.sqlite",

--- a/fedmsg.d/statscache.py
+++ b/fedmsg.d/statscache.py
@@ -5,6 +5,7 @@ hostname = socket.gethostname().split('.')[0]
 
 config = {
     "statscache.datagrepper.workers": 8,
+    "statscache.datagrepper.profile": False,
     # Consumer stuff
     "statscache.consumer.enabled": True,
     "statscache.sqlalchemy.uri": "sqlite:////var/tmp/statscache-dev-db.sqlite",

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ requires = [
     'moksha.hub>=1.4.6',
     'fedmsg_meta_fedora_infrastructure',
     'sqlalchemy',
+    'futures',
 ]
 
 tests_require = [

--- a/statscache/consumer.py
+++ b/statscache/consumer.py
@@ -38,6 +38,7 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
 
         # Prepare to process backlogged fedmsg traffic
         epoch = self.hub.config['statscache.consumer.epoch']
+        workers = self.hub.config['statscache.datagrepper.workers']
         session = statscache.plugins.init_model(uri)
 
         # Compute pairs of plugins and the point up to which they are accurate
@@ -72,7 +73,9 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
             # Delete any partially completed rows, timestamped at start
             for plugin in self.plugins:
                 plugin.revert(start, session)
-            for messages in statscache.utils.datagrep(start, stop):
+            for messages in statscache.utils.datagrep(start,
+                                                      stop,
+                                                      workers=workers):
                 for plugin in self.plugins:
                     for message in messages:
                         plugin.process(copy.deepcopy(message))

--- a/statscache/consumer.py
+++ b/statscache/consumer.py
@@ -39,6 +39,7 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
         # Prepare to process backlogged fedmsg traffic
         epoch = self.hub.config['statscache.consumer.epoch']
         workers = self.hub.config['statscache.datagrepper.workers']
+        profile = self.hub.config['statscache.datagrepper.profile']
         session = statscache.plugins.init_model(uri)
 
         # Compute pairs of plugins and the point up to which they are accurate
@@ -75,7 +76,8 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
                 plugin.revert(start, session)
             for messages in statscache.utils.datagrep(start,
                                                       stop,
-                                                      workers=workers):
+                                                      workers=workers,
+                                                      profile=profile):
                 for plugin in self.plugins:
                     for message in messages:
                         plugin.process(copy.deepcopy(message))

--- a/statscache/plugins.py
+++ b/statscache/plugins.py
@@ -142,8 +142,6 @@ class BasePlugin(object):
     backlog_delta = None # how far back to process backlog (None is unlimited)
     model = None
 
-    datagrepper_endpoint = 'https://apps.fedoraproject.org/datagrepper/raw/'
-
     def __init__(self, schedule, config, model=None):
         self.schedule = schedule
         self.config = config

--- a/statscache/utils.py
+++ b/statscache/utils.py
@@ -20,7 +20,7 @@ def find_stats_consumer(hub):
     raise ValueError('StatsConsumer not found.')
 
 
-def datagrep(start, stop, workers=1, quantum=100):
+def datagrep(start, stop, workers=1, profile=False, quantum=100):
     """ Yield messages generated in the given time interval from datagrepper
 
     Messages are ordered ascending by age (from oldest to newest), so that
@@ -49,21 +49,23 @@ def datagrep(start, stop, workers=1, quantum=100):
 
     with concurrent.futures.ThreadPoolExecutor(workers) as executor:
         # Uncomment the lines of code in this block to log profiling data
-        #page = 1
-        #net_time = time.time()
+        page = 1
+        net_time = time.time()
         for response in executor.map(query, xrange(2, pages+1)):
-            #net_time = time.time() - net_time
-            #cpu_time = time.time()
+            if profile:
+                net_time = time.time() - net_time
+                cpu_time = time.time()
             yield response.json()['raw_messages']
-            #page += 1
-            #cpu_time = time.time() - cpu_time
-            #log.info("Processed page {}/{}: {}ms NET {}ms CPU".format(
-            #    page,
-            #    pages,
-            #    int(net_time * 1000),
-            #    int(cpu_time * 1000)
-            #))
-            #net_time = time.time()
+            if profile:
+                page += 1
+                cpu_time = time.time() - cpu_time
+                log.info("Processed page {}/{}: {}ms NET {}ms CPU".format(
+                    page,
+                    pages,
+                    int(net_time * 1000),
+                    int(cpu_time * 1000)
+                ))
+                net_time = time.time()
 
 
 def init_plugins(config):

--- a/statscache/utils.py
+++ b/statscache/utils.py
@@ -20,7 +20,7 @@ def find_stats_consumer(hub):
     raise ValueError('StatsConsumer not found.')
 
 
-def datagrep(start, stop, quantum=100):
+def datagrep(start, stop, workers=1, quantum=100):
     """ Yield messages generated in the given time interval from datagrepper
 
     Messages are ordered ascending by age (from oldest to newest), so that
@@ -28,7 +28,6 @@ def datagrep(start, stop, quantum=100):
     of failure. Messages are generated in collections of the given quantum at a
     time.
     """
-    MAX_WORKERS = 8
     endpoint = 'https://apps.fedoraproject.org/datagrepper/raw/'
     session = requests.Session()
     session.params = {
@@ -48,7 +47,7 @@ def datagrep(start, stop, quantum=100):
     pages = int(data['pages'])
     del data
 
-    with concurrent.futures.ThreadPoolExecutor(MAX_WORKERS) as executor:
+    with concurrent.futures.ThreadPoolExecutor(workers) as executor:
         # Uncomment the lines of code in this block to log profiling data
         #page = 1
         #net_time = time.time()

--- a/statscache/utils.py
+++ b/statscache/utils.py
@@ -49,8 +49,22 @@ def datagrep(start, stop, quantum=100):
     del data
 
     with concurrent.futures.ThreadPoolExecutor(MAX_WORKERS) as executor:
+        # Uncomment the lines of code in this block to log profiling data
+        #page = 1
+        #net_time = time.time()
         for response in executor.map(query, xrange(2, pages+1)):
+            #net_time = time.time() - net_time
+            #cpu_time = time.time()
             yield response.json()['raw_messages']
+            #page += 1
+            #cpu_time = time.time() - cpu_time
+            #log.info("Processed page {}/{}: {}ms NET {}ms CPU".format(
+            #    page,
+            #    pages,
+            #    int(net_time * 1000),
+            #    int(cpu_time * 1000)
+            #))
+            #net_time = time.time()
 
 
 def init_plugins(config):


### PR DESCRIPTION
Employ the Python 2 backport of `concurrent.futures` to simulate non-blocking network I/O on top of the `requests` library in `statscache.utils.datagrep()`. Prior testing of statscache showed that it was able to achieve a throughput of 125-150 messages per second during the datagrepper backprocessing phase. Since a real deployment will need to sift through the entire 32 million+ message history (which would take about 3 days at that rate), I've been looking pretty intensely at ways to improve this performance, primarily through multiplexing network I/O. Moksha already brings in Twisted as a dependency, but the `StatsConsumer` must be fully initialized before the reactor runs, so that was out. (Even if this weren't the case, using Twisted would mean interlacing processing of old and new messages, adding another layer of complexity.) After some experimentation, I found that `concurrent.futures` increases backprocessing throughput to 250-350 messages per second, at which rate the entire datagrepper stream could be processed in around 24 hours. I also tried out `gevent`, but it, surprisingly, decreased throughput at every thread pool size that I used. Performance considerations aside, `concurrent.futures` is more suitable as it has minimal interference with Twisted when the reactor is run later.
