### PR TITLE
Concurrency interface for plugins

### DIFF
--- a/fedmsg.d/statscache.py
+++ b/fedmsg.d/statscache.py
@@ -4,7 +4,6 @@ hostname = socket.gethostname().split('.')[0]
 
 
 config = {
-    "statscache.datagrepper.workers": 8,
     "statscache.datagrepper.profile": False,
     # Consumer stuff
     "statscache.consumer.enabled": True,

--- a/statscache/consumer.py
+++ b/statscache/consumer.py
@@ -39,7 +39,6 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
 
         # Read configuration values
         epoch = self.hub.config['statscache.consumer.epoch']
-        workers = self.hub.config['statscache.datagrepper.workers']
         profile = self.hub.config['statscache.datagrepper.profile']
 
         # Compute pairs of plugins and the point up to which they are accurate
@@ -76,7 +75,6 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
                 plugin.revert(start, session)
             for messages in statscache.utils.datagrep(start,
                                                       stop,
-                                                      workers=workers,
                                                       profile=profile):
                 for plugin in self.plugins:
                     for message in messages:

--- a/statscache/consumer.py
+++ b/statscache/consumer.py
@@ -68,8 +68,10 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
         for (start, plugins) in plugins_by_age:
             self.plugins.extend(plugins) # Reinsert plugins
             (stop, _) = next(plugins_by_age_iter, (end_backlog, None))
-            log.info("consuming historical fedmsg traffic from %s up to %s"
-                % (start, stop))
+            log.info(
+                "consuming historical fedmsg traffic from {} up to {}"
+                .format(start, stop)
+            )
             # Delete any partially completed rows, timestamped at start
             for plugin in self.plugins:
                 plugin.revert(start, session)
@@ -92,8 +94,8 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
         # normal operation, so the worker threads will have a good opportunity
         # to catch up.
         for plugin in self.plugins:
+            log.info("launching workers for {!r}".format(plugin.ident))
             plugin.launch(session)
-        log.info("launched plugin workers")
 
         log.debug("statscache consumer initialized")
 

--- a/statscache/plugins/__init__.py
+++ b/statscache/plugins/__init__.py
@@ -8,6 +8,9 @@ from statscache.plugins.models import BaseModel, ScalarModel,\
                                       ConstrainedCategorizedLogModel
 from statscache.plugins.threads import Queue, Future, asynchronous
 
+import logging
+log = logging.getLogger("fedmsg")
+
 
 class BasePlugin(object):
     """ An abstract base class for plugins

--- a/statscache/plugins/__init__.py
+++ b/statscache/plugins/__init__.py
@@ -11,6 +11,20 @@ from statscache.plugins.threads import Queue, Future, asynchronous
 import logging
 log = logging.getLogger("fedmsg")
 
+__all__ = [
+    'Schedule',
+    'BaseModel',
+    'ScalarModel',
+    'CategorizedModel',
+    'CategorizedLogModel',
+    'ConstrainedCategorizedLogModel',
+    'Queue',
+    'Future',
+    'asynchronous',
+    'BasePlugin',
+    'AsyncPlugin',
+]
+
 
 class BasePlugin(object):
     """ An abstract base class for plugins

--- a/statscache/plugins/__init__.py
+++ b/statscache/plugins/__init__.py
@@ -129,6 +129,7 @@ class AsyncPlugin(BasePlugin):
                 log.exception("error in {!r}: {!r}".format(self.ident, error))
             worker = self.queue.dequeue()
             worker.on_success(self.work)
+            worker.on_success(lambda _: spawn(None))
             worker.on_failure(spawn)
 
         self.fill(session)

--- a/statscache/plugins/__init__.py
+++ b/statscache/plugins/__init__.py
@@ -5,6 +5,7 @@ from statscache.plugins.schedule import Schedule
 from statscache.plugins.models import BaseModel, ScalarModel,\
                                       CategorizedModel, CategorizedLogModel,\
                                       ConstrainedCategorizedLogModel
+from statscache.plugins.threads import Queue, Future, asynchronous
 
 
 class BasePlugin(object):
@@ -45,6 +46,7 @@ class BasePlugin(object):
     def __init__(self, schedule, config, model=None):
         self.schedule = schedule
         self.config = config
+        self.launched = False
         if model:
             self.model = model
 
@@ -68,6 +70,16 @@ class BasePlugin(object):
         if schedule:
             ident += '-{}'.format(schedule)
         return ident
+
+    def launch(self, session):
+        """ Launch asynchronous workers, restoring state from model if needed
+
+        This method is not guaranteed to be called before message processing
+        begins. Currently, it is invoked after backprocessing has completed.
+        The recommended usage pattern is to launch a fixed number of worker
+        threads, using the plugin thread API
+        """
+        self.launched = True
 
     @abc.abstractmethod
     def process(self, message):

--- a/statscache/plugins/__init__.py
+++ b/statscache/plugins/__init__.py
@@ -144,7 +144,9 @@ class AsyncPlugin(BasePlugin):
 
         The mechanism for storage of the results of this processing for
         eventual commit by 'self.update()', is completely up to the individual
-        plugin implementation.
+        plugin implementation. An easy way to manage this is by storing model
+        instances on the queue, whose mere mutation will be reflected in the
+        next database commit.
 
         Note that this method is called in its own thread, and may therefore
         utilize blocking I/O without disrupting any other components.

--- a/statscache/plugins/__init__.py
+++ b/statscache/plugins/__init__.py
@@ -1,5 +1,6 @@
 import abc
 import datetime
+from multiprocessing import cpu_count
 
 from statscache.plugins.schedule import Schedule
 from statscache.plugins.models import BaseModel, ScalarModel,\
@@ -44,6 +45,7 @@ class BasePlugin(object):
     model = None
 
     def __init__(self, schedule, config, model=None):
+        self.workers = cpu_count()
         self.schedule = schedule
         self.config = config
         self.launched = False

--- a/statscache/plugins/__init__.py
+++ b/statscache/plugins/__init__.py
@@ -124,9 +124,9 @@ class AsyncPlugin(BasePlugin):
         self.queue = Queue(backlog=self.workers) # work queue
 
     def launch(self, session):
-        def spawn(error):
-            if error is not None:
-                log.exception("error in {!r}: {!r}".format(self.ident, error))
+        def spawn(e):
+            if e is not None:
+                log.exception("error in '{}': '{}'".format(self.ident, e.error))
             worker = self.queue.dequeue()
             worker.on_success(self.work)
             worker.on_success(lambda _: spawn(None))

--- a/statscache/plugins/threads.py
+++ b/statscache/plugins/threads.py
@@ -84,7 +84,7 @@ class Future(object):
         type-validity of this parameter.
         """
         self._deferred = source or twisted.Deferred()
-        deferred.addCallbacks(on_success or [])
+        self._deferred.addCallbacks(on_success or [])
         for f in on_failure or []:
             self.on_failure(f)
 

--- a/statscache/plugins/threads.py
+++ b/statscache/plugins/threads.py
@@ -1,0 +1,153 @@
+import twisted.internet.defer as twisted
+import twisted.internet.threads as twisted
+
+
+__all__ = [
+    'Queue',
+    'Future',
+    'asynchronous',
+]
+
+
+class Queue(object):
+    """ A non-blocking queue for use with asynchronous code """
+
+    class OverflowError(Exception):
+        """ The queue has overflown """
+        pass
+
+    class UnderflowError(Exception):
+        """ The queue has underflown """
+        pass
+
+    def __init__(self, size=None, backlog=None):
+        self._queue = twisted.DeferredQueue(size=size, backlog=backlog)
+
+    def enqueue(self, value):
+        """ Add an item to the queue, synchronously """
+        try:
+            self._queue.put(value)
+        except twisted.QueueOverflow:
+            raise Queue.OverflowError()
+
+    def dequeue(self):
+        """ Return an item from the queue, asynchronously, using a 'Future' """
+        try:
+            return Future(self._queue.get(), [], [])
+        except twisted.QueueUnderflow:
+            raise Queue.UnderflowError()
+
+
+class Future(object):
+    """ An asynchronously computed value """
+
+    class AlreadyResolvedError(Exception):
+        """ The 'Future' has either already succeeded or already failed """
+        pass
+
+    class CancellationError(Exception):
+        """ The 'Future' has been cancelled """
+        pass
+
+    class Failure(object):
+        """ Wrapper for exceptions thrown during asynchronous execution
+
+        An instance of this class contains two attributes of consequence:
+        'error', which is the exception instance raised in the asynchronous
+        function, and 'stack', which is a list of stack frames in the same
+        format used by 'inspect.stack'.
+        """
+
+        def __init__(self, failure):
+            """ The semantics of this method are implementation-dependent """
+            self.error = failure.value
+            if isinstance(failure.value, twisted.CancelledError):
+                # Hide Twisted's original exception (shouldn't matter)
+                self.error = Future.CancellationError() 
+            self.stack = failure.frames
+
+    def __init__(self,
+                 from_deferred=None,
+                 on_success=None,
+                 on_failure=None):
+        """ Instantiate a 'Future' object
+
+        The 'from_deferred' keyword argument initializes the 'Future' to
+        encapsulate an instance of 'twisted.internet.defer.Deferred'; however,
+        note that the usage of Twisted by the statscache is considered an
+        implementation detail and subject to change.
+        """
+        self._deferred = from_deferred or twisted.Deferred()
+        deferred.addCallbacks(on_success or [])
+        for f in on_failure or []:
+            self.on_failure(f)
+
+    def on_success(self, f):
+        """ Add a handler function to take the resolved value """
+        self._deferred.addCallback(f)
+
+    def on_failure(self, f):
+        """ Add a handler function to take the resolved error
+
+        The resolved error will be wrapped in a 'Future.Failure'.
+        """
+        self._deferred.addErrback(lambda x: f(Failure(x)))
+
+    def fire(self, result):
+        """ Directly resolve this 'Future' with the given 'result' """
+        try:
+            self._deferred.callback(result)
+        except twisted.AlreadyCalledError:
+            raise Future.AlreadyResolvedError()
+
+    def fail(self, error):
+        """ Directly resolve this 'Future' with the given 'result' """
+        try:
+            self._deferred.errback(error)
+        except twisted.AlreadyCalledError:
+            raise Future.AlreadyResolvedError()
+
+    def quit(self):
+        """ Quit (i.e., cancel) this 'Future' """
+        self._deferred.cancel()
+
+    @staticmethod
+    def failure(error, on_success=None, on_failure=None):
+        """ Create a 'Future' pre-resolved with the given 'error' (failure)
+
+        Because this 'Future' cannot succeed, the success handlers given by
+        'on_success' will be ignored.
+        """
+        return Future(
+            from_deferred=twisted.fail(error),
+            on_failure=on_failure
+        )
+
+    @staticmethod
+    def success(result, on_success=None, on_failure=None):
+        """ Create a 'Future' pre-resolved with the given 'result' (success)
+
+        Because this 'Future' cannot fail, the error handlers given by
+        'on_failure' will be ignored.
+        """
+        return Future(
+            from_deferred=twisted.succeed(result),
+            on_success=on_success
+        )
+
+    @staticmethod
+    def compute(f, on_success=None, on_failure=None):
+        """ Create a 'Future' for an asynchronous computation
+
+        A fiber (i.e., green or lightweight thread) will be spawned to perform
+        the computation.
+        """
+        return lambda *args, **kwargs: Future(
+            from_deferred=twisted.deferToThread(f, *args, **kwargs),
+            on_success=on_success,
+            on_failure=on_failure
+        )
+
+
+# Decorator synonym for 'Future.compute'
+asynchronous = Future.compute

--- a/statscache/plugins/threads.py
+++ b/statscache/plugins/threads.py
@@ -67,7 +67,7 @@ class Future(object):
             mechanism, which is implementation-dependent.
             """
             self.error = failure.value
-            if isinstance(failure.value, threads.CancelledError):
+            if isinstance(failure.value, defer.CancelledError):
                 # Hide Twisted's original exception (shouldn't matter)
                 self.error = Future.CancellationError() 
             self.stack = failure.frames

--- a/statscache/plugins/threads.py
+++ b/statscache/plugins/threads.py
@@ -84,7 +84,8 @@ class Future(object):
         type-validity of this parameter.
         """
         self._deferred = source or threads.Deferred()
-        self._deferred.addCallbacks(on_success or [])
+        for f in on_success or []:
+            self.on_success(f)
         for f in on_failure or []:
             self.on_failure(f)
 

--- a/statscache/plugins/threads.py
+++ b/statscache/plugins/threads.py
@@ -91,14 +91,15 @@ class Future(object):
 
     def on_success(self, f):
         """ Add a handler function to take the resolved value """
-        self._deferred.addCallback(f)
+        self._deferred.addCallback(lambda x: (f(x), x)[1])
 
     def on_failure(self, f):
         """ Add a handler function to take the resolved error
 
         The resolved error will be wrapped in a 'Future.Failure'.
         """
-        self._deferred.addErrback(lambda x: f(Future.Failure(x)))
+        g = Future.Failure
+        self._deferred.addErrback(lambda x: (f(g(x)), x)[1])
 
     def fire(self, result):
         """ Directly resolve this 'Future' with the given 'result' """

--- a/statscache/plugins/threads.py
+++ b/statscache/plugins/threads.py
@@ -98,7 +98,7 @@ class Future(object):
 
         The resolved error will be wrapped in a 'Future.Failure'.
         """
-        self._deferred.addErrback(lambda x: f(Failure(x)))
+        self._deferred.addErrback(lambda x: f(Future.Failure(x)))
 
     def fire(self, result):
         """ Directly resolve this 'Future' with the given 'result' """

--- a/statscache/utils.py
+++ b/statscache/utils.py
@@ -3,9 +3,10 @@ import pkg_resources
 import requests
 import concurrent.futures
 import time
+from multiprocessing import cpu_count
 
-from statscache.plugins import BasePlugin, Schedule
 import statscache.plugins.models as models
+from statscache.plugins import BasePlugin, Schedule
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -24,7 +25,7 @@ def find_stats_consumer(hub):
     raise ValueError('StatsConsumer not found.')
 
 
-def datagrep(start, stop, workers=1, profile=False, quantum=100):
+def datagrep(start, stop, profile=False, quantum=100):
     """ Yield messages generated in the given time interval from datagrepper
 
     Messages are ordered ascending by age (from oldest to newest), so that
@@ -51,7 +52,7 @@ def datagrep(start, stop, workers=1, profile=False, quantum=100):
     pages = int(data['pages'])
     del data
 
-    with concurrent.futures.ThreadPoolExecutor(workers) as executor:
+    with concurrent.futures.ThreadPoolExecutor(cpu_count()) as executor:
         # Uncomment the lines of code in this block to log profiling data
         page = 1
         net_time = time.time()

--- a/statscache/utils.py
+++ b/statscache/utils.py
@@ -103,7 +103,6 @@ def init_plugins(config):
     return plugins
 
 
-
 def init_model(db_url):
     engine = create_engine(db_url)
 


### PR DESCRIPTION
Implement a basic concurrency interface for plugins on top of Twisted's threading system. This simplifies a work-queue usage pattern and abstracts away the choice of Twisted as the concurrency engine for statscache.

I've spent most of today testing it out and hunting down edge-cases, and from what I can tell, it's working pretty well. Real testcases are forthcoming; I'm working on using `mock` to implement a fairly comprehensive phony testing environment.
