### PR TITLE
Make the datagrepper endpoint configurable.

### DIFF
--- a/fedmsg.d/statscache.py
+++ b/fedmsg.d/statscache.py
@@ -5,6 +5,8 @@ hostname = socket.gethostname().split('.')[0]
 
 config = {
     "statscache.datagrepper.profile": False,
+    "statscache.datagrepper.endpoint": "https://apps.fedoraproject.org/datagrepper/raw",
+
     # Consumer stuff
     "statscache.consumer.enabled": True,
     "statscache.sqlalchemy.uri": "sqlite:////var/tmp/statscache-dev-db.sqlite",

--- a/statscache/consumer.py
+++ b/statscache/consumer.py
@@ -40,6 +40,7 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
         # Read configuration values
         epoch = self.hub.config['statscache.consumer.epoch']
         profile = self.hub.config['statscache.datagrepper.profile']
+        endpoint = self.hub.config['statscache.datagrepper.endpoint']
 
         # Compute pairs of plugins and the point up to which they are accurate
         plugins_by_age = []
@@ -77,7 +78,8 @@ class StatsConsumer(fedmsg.consumers.FedmsgConsumer):
                 plugin.revert(start, session)
             for messages in statscache.utils.datagrep(start,
                                                       stop,
-                                                      profile=profile):
+                                                      profile=profile,
+                                                      endpoint=endpoint):
                 for plugin in self.plugins:
                     for message in messages:
                         plugin.process(copy.deepcopy(message))

--- a/statscache/utils.py
+++ b/statscache/utils.py
@@ -25,7 +25,8 @@ def find_stats_consumer(hub):
     raise ValueError('StatsConsumer not found.')
 
 
-def datagrep(start, stop, profile=False, quantum=100):
+def datagrep(start, stop, profile=False, quantum=100,
+             endpoint='https://apps.fedoraproject.org/datagrepper/raw/'):
     """ Yield messages generated in the given time interval from datagrepper
 
     Messages are ordered ascending by age (from oldest to newest), so that
@@ -33,7 +34,6 @@ def datagrep(start, stop, profile=False, quantum=100):
     of failure. Messages are generated in collections of the given quantum at a
     time.
     """
-    endpoint = 'https://apps.fedoraproject.org/datagrepper/raw/'
     session = requests.Session()
     session.params = {
         'start': time.mktime(start.timetuple()),


### PR DESCRIPTION
I hit this in staging -- the staging backend tried to query the production
datagrepper and choked (since our staging env is firewalled off from prod).
Staging statscache should query staging datagrepper.
