### PR TITLE
Fix example plugin code in getting started guide

### DIFF
--- a/statscache/templates/getting_started.html
+++ b/statscache/templates/getting_started.html
@@ -72,6 +72,7 @@ import fedmsg.meta
 import sqlalchemy as sa
 
 class Model(BaseModel):
+    __tablename__ = "data_popularity"
     # inherited from BaseModel: timestamp = sa.Column(sa.DateTime, ...)
     references = sa.Column(sa.Integer, nullable=False)
     username = sa.Column(sa.UnicodeText, nullable=False, index=True)
@@ -102,7 +103,7 @@ class Plugin(BasePlugin):
                        .filter(self.model.username == username)\
                        .order_by(self.model.timestamp.desc())\
                        .first()
-            session.add_row(self.model(
+            session.add(self.model(
                 timestamp=timestamp,
                 username=username,
                 references=getattr(previous, 'references', 0) + 1


### PR DESCRIPTION
I'm getting started with statscache, and the example plugin code didn't load when I tried to run it, so I made a small change to it to make it work!

`fedmsg-hub` traces before: [first](https://gist.github.com/z2s8/28559a11a17efc39ac50a6e1923c2274#file-error1-py) [second](https://gist.github.com/z2s8/28559a11a17efc39ac50a6e1923c2274#file-error2-py)
and the succeeded load after the fix, with the newly created `popularity` plugin: [fixed](https://gist.github.com/z2s8/28559a11a17efc39ac50a6e1923c2274#file-success-py)